### PR TITLE
Fix API documentation inaccuracies

### DIFF
--- a/api/authentication.mdx
+++ b/api/authentication.mdx
@@ -51,13 +51,12 @@ Never commit API keys to version control or share them publicly.
 ### Via Command Line
 
 ```bash
-# Create a test API key
-cd go/orchestrator
+# Create a test API key (run from repo root)
 make seed-api-key
 
 # Output
-API Key created: sk_test_123456
-User ID: test-user
+✅ Test API key created. Use 'sk_test_123456' for testing.
+Note: Authentication is disabled by default (GATEWAY_SKIP_AUTH=1)
 ```
 
 ### Via API (Future)
@@ -105,15 +104,18 @@ handle = client.submit_task(query="Hello world")
 
 ## Rate Limiting
 
-Shannon enforces rate limits per API key using a token bucket algorithm:
+Shannon enforces rate limits per API key using a fixed-window counter:
 
 ### Default Limits
 
-| Limit Type | Default Value | Burst |
-|------------|---------------|-------|
-| Requests per minute | 60 | 100 |
-| Tokens per minute | 100,000 | 150,000 |
-| Concurrent tasks | 10 | 15 |
+| Limit Type | Default Value |
+|------------|---------------|
+| Requests per minute | 60 |
+| Burst allowance | 10 |
+
+<Note>
+Token budgets and concurrent task limits are enforced at the workflow level by the orchestrator, not at the gateway layer.
+</Note>
 
 ### Rate Limit Headers
 
@@ -190,7 +192,7 @@ curl -X POST http://localhost:8080/api/v1/tasks \
 
 Each tenant has:
 - Isolated session storage
-- Separate vector collections in Qdrant
+- Per-tenant isolation via payload filters (`tenant_id`) within shared Qdrant collections
 - Independent budget tracking
 - Dedicated metrics
 

--- a/api/overview.mdx
+++ b/api/overview.mdx
@@ -39,6 +39,7 @@ The REST API is the recommended interface for most applications. It provides:
 | `/tasks/{id}/events` | GET | Get historical task events |
 | `/tasks/{id}/stream` | GET | Stream task events (SSE) |
 | `/stream/sse` | GET | Direct SSE via gateway proxy (`workflow_id` query) |
+| `/stream/ws` | GET | WebSocket streaming endpoint (`workflow_id` query) |
 | `/openapi.json` | GET | OpenAPI specification |
 | `/health` | GET | Health check |
 


### PR DESCRIPTION
## Summary

This PR corrects several inaccuracies in the Shannon API documentation that were identified by comparing the docs against the actual codebase implementation.

## Changes

### 1. API Key Seeding Command Path (authentication.mdx)
- **Fixed**: Removed incorrect `cd go/orchestrator` instruction
- **Reason**: `make seed-api-key` target is in the root Makefile, not in go/orchestrator
- **Verified in**: Makefile:138-143

### 2. Rate Limiting Algorithm & Defaults (authentication.mdx)
- **Fixed**: Changed from "token bucket algorithm" to "fixed-window counter"
- **Fixed**: Updated defaults from 60 rpm (burst 100) to 60 rpm (burst 10)
- **Removed**: Misleading "tokens per minute" and "concurrent tasks" limits
- **Added**: Note clarifying token budgets are enforced at workflow level
- **Reason**: Implementation uses Redis INCR with 1-minute window, not token bucket
- **Verified in**: go/orchestrator/cmd/gateway/internal/middleware/ratelimit.go:29-30, 76-104

### 3. Multi-Tenancy Qdrant Collections (authentication.mdx)
- **Fixed**: Changed from "Separate vector collections in Qdrant" to "Per-tenant isolation via payload filters (`tenant_id`) within shared Qdrant collections"
- **Reason**: Shannon uses shared collections with tenant filtering, not separate collections per tenant
- **Verified in**: go/orchestrator/internal/vectordb/client.go:240-257

### 4. WebSocket Endpoint (overview.mdx)
- **Added**: `/stream/ws` endpoint to API endpoints table
- **Reason**: Gateway exposes WebSocket endpoint but it wasn't documented
- **Verified in**: go/orchestrator/cmd/gateway/main.go:207-215

## Verification

All changes have been cross-referenced with the Shannon codebase at `/Users/wayland/Code_Ptmind/Shannon` to ensure accuracy.

## Impact

- Improves documentation accuracy for developers integrating with Shannon
- Prevents confusion about actual rate limiting behavior
- Clarifies multi-tenancy implementation details
- Documents the complete set of available API endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)